### PR TITLE
Updates opensim module

### DIFF
--- a/bundles/opensim/events.php
+++ b/bundles/opensim/events.php
@@ -36,7 +36,7 @@ if((bool)$db_is_ready)
         }
         else
         {
-            Log::error('Opensim event: update account for ' . $account->firstname . ' ' . $account->lastname . ' does not exist.');
+            Log::error('Opensim event: update account for [' . $user->uuid . '] does not exist.');
         }
     });
 


### PR DESCRIPTION
When account is not found the $account->firstname is null. Updated to use $user->uuid instead
